### PR TITLE
Update README explaining the repo has been archived

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,9 @@
 = Arduino Board Discovery (Golang)
 Alessandro Sanino <a.sanino@bcmi-labs.cc>
 
+**IMPORTANT: this repo has been archived** +
+The `board-discovery` project has been superseded by the https://github.com/arduino/pluggable-discovery-protocol-handler[pluggable-discovery-protocol-handler], more directly by the https://github.com/arduino/serial-discovery[serial] and https://github.com/arduino/mdns-discovery[mdns] discovery plugins.
+
 This package allows to discover and monitor Arduino boards connected to the network or the serial ports.
 
 === Getting the package


### PR DESCRIPTION
Adds a note to the README file, explaining the repository has been archived.
To be merged before archiving the repository.